### PR TITLE
Fix issue #5

### DIFF
--- a/src/murmur.c
+++ b/src/murmur.c
@@ -9,7 +9,7 @@
 
 #include "murmur.h"
 
-#define FORCE_INLINE __attribute__((always_inline))
+#define FORCE_INLINE inline __attribute__((always_inline))
 
 FORCE_INLINE uint32_t rotl32 ( uint32_t x, int8_t r )
 {


### PR DESCRIPTION
As @larsendt mentioned in #5 [0](https://github.com/larsendt/hashtable/issues/5), we can fix this issue by adding the
inline keyword to the macro.

From [1](https://github.com/zfsonlinux/zfs/commit/10be533e3344f523e1b8d6ab4f0658897a95ac02):

```
The '__attribute__((always_inline))' does not strictly imply
'inline'.  Newer versions of gcc detect this misuse and issue
the following warning.  Including the missing 'inline' resolves
the build warning.
```

After adding the inline keyword (as in [1](https://github.com/zfsonlinux/zfs/commit/10be533e3344f523e1b8d6ab4f0658897a95ac02)), the lib builds fine for me.
