### PR TITLE
Murmur optional alternative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SRCDIR	= src
 CC 		= gcc
-CFLAGS	= -Wall -Wextra -g -DDEBUG -DTEST
+CFLAGS	= -Wall -Wextra -g -DDEBUG -DTEST -D__WITH_MURMUR
 LFLAGS	= -lrt -L. -lhashtable
 
 all: hashtable-test hashtable-lib

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 SRCDIR	= src
 CC 		= gcc
-CFLAGS	= -Wall -Wextra -g -DDEBUG -DTEST -D__WITH_MURMUR
+
+MURMUR  = -D__WITH_MURMUR
+CFLAGS	= -Wall -Wextra -g -DDEBUG -DTEST $(MURMUR)
 LFLAGS	= -lrt -L. -lhashtable
 
 all: hashtable-test hashtable-lib
+
+without_murmur:
+	$(MAKE) MURMUR= all
 
 hashtable-lib: $(SRCDIR)/hashtable.h $(SRCDIR)/hashtable.c $(SRCDIR)/murmur.h $(SRCDIR)/murmur.c
 	$(CC) $(CFLAGS) $(SRCDIR)/hashtable.c $(SRCDIR)/murmur.c -fPIC -rdynamic -shared -o libhashtable.so

--- a/src/hashfunc.h
+++ b/src/hashfunc.h
@@ -1,0 +1,6 @@
+#ifndef __HASHFUNC_H__
+#define __HASHFUNC_H__
+
+typedef void (HashFunc)(const void *key, int len, uint32_t seed, void *out);
+
+#endif //__HASHFUNC_H__

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -335,7 +335,12 @@ void** ht_keys(hash_table *table, unsigned int *key_count)
 void ht_clear(hash_table *table)
 {
     ht_destroy(table);
-    ht_init(table, table->flags, table->max_load_factor);
+
+    ht_init(table, table->flags, table->max_load_factor
+#ifndef __WITH_MURMUR
+    , table->hashfunc_x86_32, table->hashfunc_x86_128, table->hashfunc_x64_128
+#endif //__WITH_MURMUR
+    );
 }
 
 unsigned int ht_index(hash_table *table, void *key, size_t key_size)

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -80,7 +80,7 @@ void he_set_value(int flags, hash_entry *entry, void *value, size_t value_size);
 
 void ht_init(hash_table *table, ht_flags flags, double max_load_factor
 #ifndef __WITH_MURMUR
-        , HashFunc for_x86_32, HashFunc for_x86_128, HashFunc for_x64_128
+        , HashFunc *for_x86_32, HashFunc *for_x86_128, HashFunc *for_x64_128
 #endif //__WITH_MURMUR
         )
 {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -4,7 +4,11 @@
 /// @author Dane Larsen
 
 #include "hashtable.h"
+#include "hashfunc.h"
+
+#ifdef __WITH_MURMUR
 #include "murmur.h"
+#endif //__WITH_MURMUR
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -74,8 +78,24 @@ void he_set_value(int flags, hash_entry *entry, void *value, size_t value_size);
 // HashTable functions
 //-----------------------------------
 
-void ht_init(hash_table *table, ht_flags flags, double max_load_factor)
+void ht_init(hash_table *table, ht_flags flags, double max_load_factor
+#ifndef __WITH_MURMUR
+        , HashFunc for_x86_32, HashFunc for_x86_128, HashFunc for_x64_128
+#endif //__WITH_MURMUR
+        )
 {
+#ifdef __WITH_MURMUR
+    table->hashfunc_x86_32  = MurmurHash3_x86_32;
+    table->hashfunc_x86_128 = MurmurHash3_x86_128;
+    table->hashfunc_x64_128 = MurmurHash3_x64_128;
+
+#else //__WITH_MURMUR
+    table->hashfunc_x86_32  = for_x86_32;
+    table->hashfunc_x86_128 = for_x86_128;
+    table->hashfunc_x64_128 = for_x64_128;
+
+#endif //__WITH_MURMUR
+
     table->array_size = HT_INITIAL_SIZE;
     table->array = malloc(table->array_size * sizeof(*(table->array)));
     if(table->array == NULL) {
@@ -322,7 +342,7 @@ unsigned int ht_index(hash_table *table, void *key, size_t key_size)
 {
     uint32_t index;
     // 32 bits of murmur seems to fare pretty well
-    MurmurHash3_x86_32(key, key_size, global_seed, &index);
+    table->hashfunc_x86_32(key, key_size, global_seed, &index);
     index %= table->array_size;
     return index;
 }

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -70,7 +70,7 @@ typedef enum {
 ///        of collisions increases beyond 1/10th of the size of the table
 void ht_init(hash_table *table, ht_flags flags, double max_load_factor
 #ifndef __WITH_MURMUR
-        , HashFunc for_x86_32, HashFunc for_x86_128, HashFunc for_x64_128
+        , HashFunc *for_x86_32, HashFunc *for_x86_128, HashFunc *for_x64_128
 #endif //__WITH_MURMUR
         );
 

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "hashfunc.h"
+
 /// The initial size of the hash table.
 #define HT_INITIAL_SIZE 64
 
@@ -17,6 +19,15 @@ typedef struct hash_entry hash_entry;
 
 /// The primary hashtable struct
 typedef struct hash_table {
+    // hash function for x86_32
+    HashFunc *hashfunc_x86_32;
+
+    // hash function for x86_128
+    HashFunc *hashfunc_x86_128;
+
+    // hash function for x64_128
+    HashFunc *hashfunc_x64_128;
+
     /// The number of keys in the hash table.
     unsigned int key_count;
     /// The size of the internal array.
@@ -57,7 +68,11 @@ typedef enum {
 /// @param max_load_factor The ratio of collisions:table_size before an autoresize is triggered
 ///        for example: if max_load_factor = 0.1, the table will resize if the number
 ///        of collisions increases beyond 1/10th of the size of the table
-void ht_init(hash_table *table, ht_flags flags, double max_load_factor);
+void ht_init(hash_table *table, ht_flags flags, double max_load_factor
+#ifndef __WITH_MURMUR
+        , HashFunc for_x86_32, HashFunc for_x86_128, HashFunc for_x64_128
+#endif //__WITH_MURMUR
+        );
 
 /// @brief Destroys the hash_table struct and frees all relevant memory.
 /// @param table A pointer to the hash table.

--- a/src/murmur.c
+++ b/src/murmur.c
@@ -1,3 +1,5 @@
+#ifdef __WITH_MURMUR
+
 //-----------------------------------------------------------------------------
 // MurmurHash3 was written by Austin Appleby, and is placed in the public
 // domain. The author hereby disclaims copyright to this source code.
@@ -298,3 +300,5 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 }
 
 //-----------------------------------------------------------------------------
+
+#endif //__WITH_MURMUR

--- a/src/murmur.h
+++ b/src/murmur.h
@@ -1,3 +1,4 @@
+#ifdef __WITH_MURMUR
 //-----------------------------------------------------------------------------
 // MurmurHash3 was written by Austin Appleby, and is placed in the public
 // domain. The author hereby disclaims copyright to this source code.
@@ -7,8 +8,11 @@
 
 #include <stdint.h>
 
-void MurmurHash3_x86_32  ( const void * key, int len, uint32_t seed, void * out );
-void MurmurHash3_x86_128 ( const void * key, int len, uint32_t seed, void * out );
-void MurmurHash3_x64_128 ( const void * key, int len, uint32_t seed, void * out );
+#include "hashfunc.h"
+
+HashFunc MurmurHash3_x86_32;
+HashFunc MurmurHash3_x86_128;
+HashFunc MurmurHash3_x64_128;
 
 #endif // _MURMURHASH3_H_
+#endif //__WITH_MURMUR


### PR DESCRIPTION
This patch adds the option to compile the library without murmur as hashing algorithm. If compiled without murmur, the `ht_init()` function signature is changed and gets function pointers to the hashing functions. 

I was not able to test the lib, as the tests do not run (described in #7). It compiled fine for me, except the one error when compiling without murmur, that main.c fails because the function signature does not match anymore. This is a wanted behavior, as we are now able to compile the lib into own applications by including the source directly (not over a lib*.so) and set our hashing functions on runtime.

The lib provides now per-hashtable instance hashing functions.

Tell me what you think about it, comments and improvement requests heavily welcome!
