### PR TITLE
allow alternative init size

### DIFF
--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -10,7 +10,9 @@
 #include <stddef.h>
 
 /// The initial size of the hash table.
+#ifndef HT_INITIAL_SIZE
 #define HT_INITIAL_SIZE 64
+#endif //HT_INITIAL_SIZE
 
 /// The hash_entry struct. This is considered to be private
 typedef struct hash_entry hash_entry;


### PR DESCRIPTION
This patch allows an alternative init size, when compiling the library directly into a software.

Note that this does not touch the size if the program is compiled to a library!
